### PR TITLE
feat: add ServiceMonitor to chart

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,8 +3,8 @@ name: Lint and Test Charts
 on:
   pull_request:
     paths:
-      - 'charts/templates/**'
-      - 'charts/Chart.yaml'
+      - 'charts/uptime-kuma/templates/**'
+      - 'charts/uptime-kuma/Chart.yaml'
 
 jobs:
   lint-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'charts/Chart.yaml'
+      - 'charts/uptime-kuma/Chart.yaml'
 
 jobs:
   release:

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -11,4 +11,4 @@ name: uptime-kuma
 sources:
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.9.3
+version: 2.10.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -56,6 +56,17 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor |
+| serviceMonitor.annotations | object | `{}` | Additional annotations to add to the ServiceMonitor |
+| serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.interval | string | `"60s"` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
+| serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
+| serviceMonitor.namespace | string | `nil` | Namespace where the ServiceMonitor resource should be created, default is the same as the release namespace |
+| serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| serviceMonitor.scheme | string | `nil` | Scheme to use when scraping, e.g. http (default) or https. |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | Timeout if metrics can't be retrieved in given time interval |
+| serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector, only select Prometheus's with these labels (if not set, select any Prometheus) |
+| serviceMonitor.tlsConfig | object | `{}` | TLS configuration to use when scraping, only applicable for scheme https. |
 | strategy.type | string | `"Recreate"` |  |
 | tolerations | list | `[]` |  |
 | useDeploy | bool | `true` |  |

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -1,6 +1,6 @@
 # uptime-kuma
 
-![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.3](https://img.shields.io/badge/AppVersion-1.21.3-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.3](https://img.shields.io/badge/AppVersion-1.21.3-informational?style=flat-square)
 
 A self-hosted Monitoring tool like "Uptime-Robot".
 
@@ -74,4 +74,3 @@ A self-hosted Monitoring tool like "Uptime-Robot".
 | volume.enabled | bool | `true` |  |
 | volume.existingClaim | string | `""` |  |
 | volume.size | string | `"4Gi"` |  |
-

--- a/charts/uptime-kuma/templates/servicemonitor.yaml
+++ b/charts/uptime-kuma/templates/servicemonitor.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "uptime-kuma.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "uptime-kuma.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- with .Values.serviceMonitor.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -122,3 +122,30 @@ volume:
 
 strategy:
   type: Recreate
+
+# Prometheus ServiceMonitor configuration
+serviceMonitor:
+  enabled: false
+  # -- Scrape interval. If not set, the Prometheus default scrape interval is used.
+  interval: 60s
+  # -- Timeout if metrics can't be retrieved in given time interval
+  scrapeTimeout: 10s
+  # -- Scheme to use when scraping, e.g. http (default) or https.
+  scheme: ~
+  # -- TLS configuration to use when scraping, only applicable for scheme https.
+  tlsConfig: {}
+  # -- Prometheus [RelabelConfigs] to apply to samples before scraping
+  relabelings: []
+  # -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestion
+  metricRelabelings: []
+  # -- Prometheus ServiceMonitor selector, only select Prometheus's with these
+  # labels (if not set, select any Prometheus)
+  selector: {}
+
+  # -- Namespace where the ServiceMonitor resource should be created, default is
+  # the same as the release namespace
+  namespace: ~
+  # -- Additional labels to add to the ServiceMonitor
+  additionalLabels: {}
+  # -- Additional annotations to add to the ServiceMonitor
+  annotations: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Check if an open Issue exists that is solved by your changes.

 Thank you for contributing! I will try to test and integrate the change as soon as possible, but be aware that I can't immediately respond to every request.

 -->

**Description of the change**

Adds a `ServiceMonitor` resource if the enabled and the cluster supports it. This will instruct a deployed Prometheus instance in the cluster to scrape Uptime Kuma metrics.

**Benefits**

Uptime Kuma metrics automatically show up in Prometheus.

**Possible drawbacks**

None known.

**Applicable issues**

- dirsigler/uptime-kuma-helm/issues/58

**Additional information**

The `ServiceMonitor` template will check if the cluster does have the `monitoring.coreos.com/v1` API capability and only create the object if that check succeeds. This will prevent deployment failure with `serviceMonitor.enabled: true` in clusters missing the Prometheus monitoring stack.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
